### PR TITLE
Add HexDebug splicing table iota renderer definitions

### DIFF
--- a/src/main/resources/assets/hexpose/hexdebug_splicing_iotas/identifier.json
+++ b/src/main/resources/assets/hexpose/hexdebug_splicing_iotas/identifier.json
@@ -1,0 +1,4 @@
+{
+  "parent": "hexdebug:builtin/type",
+  "use_iota_color": false
+}

--- a/src/main/resources/assets/hexpose/hexdebug_splicing_iotas/item_stack.json
+++ b/src/main/resources/assets/hexpose/hexdebug_splicing_iotas/item_stack.json
@@ -1,0 +1,6 @@
+{
+  "type": "hexdebug:item",
+  "item_path": "hexpose:stack_id",
+  "count_path": "hexpose:stack_count",
+  "tag_path": "hexpose:stack_tag"
+}

--- a/src/main/resources/assets/hexpose/hexdebug_splicing_iotas/text.json
+++ b/src/main/resources/assets/hexpose/hexdebug_splicing_iotas/text.json
@@ -1,0 +1,3 @@
+{
+  "parent": "hexdebug:builtin/string"
+}


### PR DESCRIPTION
Requires HexDebug 0.7.0 (currently unreleased).

Identifier iotas are set to `"use_iota_color": false` because the identifier colour is very close to the background colour.

<img width="1560" height="327" alt="image" src="https://github.com/user-attachments/assets/4f591397-f48f-4661-afd4-42225a6e879f" />
